### PR TITLE
Query Context Only + More metadata of the chunk

### DIFF
--- a/chunking/repo.py
+++ b/chunking/repo.py
@@ -22,7 +22,7 @@ def get_github_repo(
     os.makedirs(repo_dir, exist_ok=True)
 
     # Create a GitHub instance
-    g = Github(github_token)
+    g = Github(github_token) if github_token else Github()
 
     # Get the repository
     repository = g.get_repo(repo)
@@ -46,7 +46,9 @@ def get_github_repo(
     # Save and extract the zip file
     zip_file = BytesIO(response.content)
     with zipfile.ZipFile(zip_file) as zf:
+        extracted_folder = zf.namelist()[0].split('/')[0]
         zf.extractall(repo_dir)
 
-    print(f"Repository downloaded and extracted to: {repo_dir}")
-    return repo_dir
+    full_extracted_path = os.path.join(repo_dir, extracted_folder)
+    print(f"Repository downloaded and extracted to: {full_extracted_path}")
+    return full_extracted_path


### PR DESCRIPTION
Allow API endpoint to only query context, also include start/end position of a chunk in the file for future processing

### Description

This pull request enhances the CodeChunker functionality by introducing more detailed position information for code chunks and adds an option to query only context in the RAG system. The main changes include:

1. Addition of a new `Position` dataclass in `chunking/code_chunker.py` to represent line, character, and byte positions.
2. Update of the `CodeChunk` class to include `start` and `end` Position objects.
3. Modification of chunk creation logic in `CodeChunker` to populate start and end positions.
4. Improvement of file path handling in `get_github_repo` function in `chunking/repo.py` to remove leading separator and zip folder name.
5. Introduction of an option to query only context in the RAG system in `examples/palmier-api.py`.

These changes improve the precision of code chunk positioning, which can be useful for more accurate code navigation and analysis. The addition of the "only_need_context" option in the RAG system allows for retrieving context without generating a response, potentially improving efficiency for certain use cases.

### Changes that Break Backward Compatibility

The `CodeChunk` class in `chunking/code_chunker.py` has been modified to include `start` and `end` Position objects. Any code that relies on the previous structure of `CodeChunk` may need to be updated to accommodate these new fields.

### Documentation

N/A

*Created with [Palmier](https://www.palmier.io)*