### PR TITLE
fix embedding_func

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -175,7 +175,7 @@ class LightRAG:
         self.chunk_entity_relation_graph = self.graph_storage_cls(
             namespace="chunk_entity_relation",
             global_config=asdict(self),
-            embedding_func=self.embedding_func,
+            # embedding_func=self.embedding_func,
         )
         ####
         # add embedding func by walter over


### PR DESCRIPTION
### Description

This pull request addresses an issue with the `embedding_func` in the `lightrag/lightrag.py` file. The main change involves commenting out the `embedding_func` parameter in the initialization of the `chunk_entity_relation_graph`. This modification appears to be a fix for a problem related to the embedding function usage in the graph storage class.

The change is implemented by adding a comment to the line that previously passed the `embedding_func` to the graph storage class constructor. A comment at the end of the patch suggests that this change was made by a developer named Walter.

### Changes that Break Backward Compatibility

This change may potentially break backward compatibility for code that relies on the `embedding_func` being passed to the `chunk_entity_relation_graph`. Users of this class might need to update their code if they were expecting the embedding function to be available in the graph storage instance.

### Documentation

N/A

*Created with [Palmier](https://www.palmier.io)*