### PR TITLE
Include File Path in Source

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -602,9 +602,9 @@ async def _build_local_query_context(
         )
     relations_context = list_of_list_to_csv(relations_section_list)
 
-    text_units_section_list = [["id", "content"]]
+    text_units_section_list = [["id", "content", "file_path"]]
     for i, t in enumerate(use_text_units):
-        text_units_section_list.append([i, t["content"]])
+        text_units_section_list.append([i, t["content"], t["file_path"]])
     text_units_context = list_of_list_to_csv(text_units_section_list)
     return f"""
 -----Entities-----
@@ -891,9 +891,9 @@ async def _build_global_query_context(
         )
     entities_context = list_of_list_to_csv(entites_section_list)
 
-    text_units_section_list = [["id", "content"]]
+    text_units_section_list = [["id", "content", "file_path"]]
     for i, t in enumerate(use_text_units):
-        text_units_section_list.append([i, t["content"]])
+        text_units_section_list.append([i, t["content"], t["file_path"]])
     text_units_context = list_of_list_to_csv(text_units_section_list)
 
     return f"""


### PR DESCRIPTION
Update _build_local_query_context and _build_global_query_context functions to include file_path in text units section lists. This change enhances the context provided for text units by adding their associated file paths.

- Modify text_units_section_list header to include \"file_path\"
- Update text_units_section_list append operation to include t[\"file_path\"]
- Apply changes in both local and global query context building functions

This enhancement will provide more detailed information about the source of text units, which can be useful for debugging and analysis purposes.