### PR TITLE
[feature] Add start and end line information to code chunks

### DIFF
--- a/lightrag/__init__.py
+++ b/lightrag/__init__.py
@@ -1,5 +1,5 @@
 from .lightrag import LightRAG as LightRAG, QueryParam as QueryParam
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 __author__ = "Original: Zirui Guo, Modified: Harrison Tin"
 __url__ = "https://github.com/palmier-io/palmier-lightrag"

--- a/lightrag/chunking/__init__.py
+++ b/lightrag/chunking/__init__.py
@@ -2,9 +2,9 @@ from .code_chunker import CodeChunker, traverse_directory
 from .language_parsers import get_language_from_file, FILES_TO_IGNORE, SUPPORT_LANGUAGES
 
 __all__ = [
-    'CodeChunker',
-    'traverse_directory',
-    'get_language_from_file',
-    'FILES_TO_IGNORE',
-    'SUPPORT_LANGUAGES',
+    "CodeChunker",
+    "traverse_directory",
+    "get_language_from_file",
+    "FILES_TO_IGNORE",
+    "SUPPORT_LANGUAGES",
 ]

--- a/lightrag/chunking/code_chunker.py
+++ b/lightrag/chunking/code_chunker.py
@@ -6,12 +6,12 @@ import logging
 from typing import Dict, Any, List, Optional
 from enum import Enum
 from dataclasses import dataclass
-from .language_parsers import (
+from lightrag.chunking.language_parsers import (
     get_language_from_file,
     SUPPORT_LANGUAGES,
     FILES_TO_IGNORE,
 )
-from ..prompt import PROMPTS
+from lightrag.prompt import PROMPTS
 
 
 class ChunkType(Enum):
@@ -199,8 +199,8 @@ class CodeChunker:
         self, content: str, file_path: str, current_index: int = 0
     ) -> List[CodeChunk]:
         """Chunk the content of a file by token size"""
-
         tokens = self.encoding.encode(content)
+        lines = content.split('\n')
         results = []
 
         for index, start in enumerate(
@@ -208,15 +208,30 @@ class CodeChunker:
         ):
             end = start + self.target_tokens
             chunk_content = self.encoding.decode(tokens[start:end])
+            
+            # Get the text before our chunk to count newlines for start_line
+            text_before = self.encoding.decode(tokens[:start])
+            start_line = text_before.count('\n')
+            
+            # Get the actual lines for this chunk
+            chunk_lines = lines[start_line:]
+            chunk_text = '\n'.join(chunk_lines)
+            
+            # Find where our chunk content ends in the original lines
+            chunk_end_pos = chunk_text.find(chunk_content) + len(chunk_content)
+            end_line = start_line + chunk_text[:chunk_end_pos].count('\n')
+
+            # Use the original lines to reconstruct the content
+            content = '\n'.join(lines[start_line:end_line + 1])
 
             results.append(
                 CodeChunk(
                     index=current_index + index,
                     file_path=file_path,
-                    content=chunk_content.strip(),
+                    content=content,
                     token_count=min(self.target_tokens, len(tokens) - start),
-                    start=Position(byte=start),
-                    end=Position(byte=end),
+                    start=Position(byte=start, line=start_line, character=0),
+                    end=Position(byte=end, line=end_line, character=0),
                     chunk_type=ChunkType.TOKEN_SIZE,
                 )
             )

--- a/lightrag/chunking/code_chunker.py
+++ b/lightrag/chunking/code_chunker.py
@@ -183,7 +183,7 @@ class CodeChunker:
         if language_name == "text only":
             chunks = self._chunking_by_token_size(content, relative_file_path)
         elif language_name in SUPPORT_LANGUAGES:
-            content_bytes = content.encode('utf-8')
+            content_bytes = content.encode("utf-8")
             chunks = self._chunking_by_tree_sitter(
                 content_bytes, language_name, relative_file_path
             )
@@ -200,7 +200,7 @@ class CodeChunker:
     ) -> List[CodeChunk]:
         """Chunk the content of a file by token size"""
         tokens = self.encoding.encode(content)
-        lines = content.split('\n')
+        lines = content.split("\n")
         results = []
 
         for index, start in enumerate(
@@ -208,21 +208,21 @@ class CodeChunker:
         ):
             end = start + self.target_tokens
             chunk_content = self.encoding.decode(tokens[start:end])
-            
+
             # Get the text before our chunk to count newlines for start_line
             text_before = self.encoding.decode(tokens[:start])
-            start_line = text_before.count('\n')
-            
+            start_line = text_before.count("\n")
+
             # Get the actual lines for this chunk
             chunk_lines = lines[start_line:]
-            chunk_text = '\n'.join(chunk_lines)
-            
+            chunk_text = "\n".join(chunk_lines)
+
             # Find where our chunk content ends in the original lines
             chunk_end_pos = chunk_text.find(chunk_content) + len(chunk_content)
-            end_line = start_line + chunk_text[:chunk_end_pos].count('\n')
+            end_line = start_line + chunk_text[:chunk_end_pos].count("\n")
 
             # Use the original lines to reconstruct the content
-            content = '\n'.join(lines[start_line:end_line + 1])
+            content = "\n".join(lines[start_line : end_line + 1])
 
             results.append(
                 CodeChunk(
@@ -402,6 +402,7 @@ def traverse_directory(root_dir: str) -> List[str]:
         for file in files:
             file_list.append(os.path.join(root, file))
     return file_list
+
 
 # NOT USED
 def generate_file_summary(

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -37,7 +37,7 @@ class Neo4JStorage(BaseGraphStorage):
         URI = os.environ["NEO4J_URI"]
         USERNAME = os.environ["NEO4J_USERNAME"]
         PASSWORD = os.environ["NEO4J_PASSWORD"]
-        
+
         # Initialize driver without binding to a specific loop
         self._driver: AsyncDriver = AsyncGraphDatabase.driver(
             URI, auth=(USERNAME, PASSWORD)
@@ -279,7 +279,9 @@ class Neo4JStorage(BaseGraphStorage):
         try:
             async with self._driver.session() as session:
                 results = await session.run(
-                    query, repository_id=self.repository_id, source_node_id=source_node_id
+                    query,
+                    repository_id=self.repository_id,
+                    source_node_id=source_node_id,
                 )
                 edges = []
                 async for record in results:
@@ -320,6 +322,7 @@ class Neo4JStorage(BaseGraphStorage):
                     repository_id=self.repository_id,
                     properties=properties,
                 )
+
             async with self._driver.session() as session:
                 await session.execute_write(_do_upsert)
         except Exception as e:
@@ -359,6 +362,7 @@ class Neo4JStorage(BaseGraphStorage):
                     target_node_id=target_node_id,
                     properties=edge_properties,
                 )
+
             async with self._driver.session() as session:
                 await session.execute_write(_do_upsert_edge)
         except Exception as e:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -257,7 +257,7 @@ class LightRAG:
     def insert_files(self, directory: str, file_paths: Optional[list[str]] = None):
         """
         Palmier Specific - inserting file(s) to the knowledge graph
-        
+
         Input:
         - directory: the directory where the github repository is downloaded to
         - file_paths [optional]: a list of full file paths to insert. If not provided, the function will traverse the directory and insert all files.
@@ -265,7 +265,9 @@ class LightRAG:
         loop = always_get_an_event_loop()
         return loop.run_until_complete(self.ainsert_files(directory, file_paths))
 
-    async def ainsert_files(self, directory: str, file_paths: Optional[list[str]] = None):
+    async def ainsert_files(
+        self, directory: str, file_paths: Optional[list[str]] = None
+    ):
         """Palmier Specific - inserting file(s) to the knowledge graph"""
         update_storage = False
         try:
@@ -278,14 +280,17 @@ class LightRAG:
             )
 
             if file_paths is None:
-                logger.info(f"[Traversing] No file provided to ainsert_files, traversing {directory}")
+                logger.info(
+                    f"[Traversing] No file provided to ainsert_files, traversing {directory}"
+                )
                 file_paths = traverse_directory(directory)
 
             # Create a new document for each file
-            logger.info(f"[Filtering] processing {len(file_paths)} files at {directory}")
+            logger.info(
+                f"[Filtering] processing {len(file_paths)} files at {directory}"
+            )
             new_docs = {}
             for full_file_path in file_paths:
-
                 # Filter out unwanted/unsupported files
                 if any(full_file_path.endswith(ext) for ext in FILES_TO_IGNORE):
                     continue
@@ -298,7 +303,9 @@ class LightRAG:
 
                 relative_file_path = os.path.relpath(full_file_path, directory)
                 # use hash(file_path) as doc_id
-                new_docs[compute_mdhash_id(relative_file_path.strip(), prefix="doc-")] = {
+                new_docs[
+                    compute_mdhash_id(relative_file_path.strip(), prefix="doc-")
+                ] = {
                     "file_path": relative_file_path,
                     "language": language,
                     "content": content,
@@ -393,7 +400,7 @@ class LightRAG:
     def delete_files(self, directory: str, file_paths: list[str]):
         """
         Palmier Specific - deleting file(s) from the knowledge graph
-        
+
         Input:
         - directory: the directory where the github repository is downloaded to
         - file_paths: a list of full file paths to delete

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -602,9 +602,10 @@ async def _build_local_query_context(
         )
     relations_context = list_of_list_to_csv(relations_section_list)
 
-    text_units_section_list = [["id", "content", "file_path"]]
+    text_units_section_list = [["id", "content", "file_path", "start_line", "end_line"]]
     for i, t in enumerate(use_text_units):
-        text_units_section_list.append([i, t["content"], t["file_path"]])
+        print(t)
+        text_units_section_list.append([i, t["content"], t["file_path"], t["start"]["line"], t["end"]["line"]])
     text_units_context = list_of_list_to_csv(text_units_section_list)
     return f"""
 -----Entities-----
@@ -891,9 +892,10 @@ async def _build_global_query_context(
         )
     entities_context = list_of_list_to_csv(entites_section_list)
 
-    text_units_section_list = [["id", "content", "file_path"]]
+    text_units_section_list = [["id", "content", "file_path", "start_line", "end_line"]]
     for i, t in enumerate(use_text_units):
-        text_units_section_list.append([i, t["content"], t["file_path"]])
+        print(t)
+        text_units_section_list.append([i, t["content"], t["file_path"], t["start"]["line"], t["end"]["line"]])
     text_units_context = list_of_list_to_csv(text_units_section_list)
 
     return f"""

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -605,7 +605,9 @@ async def _build_local_query_context(
     text_units_section_list = [["id", "content", "file_path", "start_line", "end_line"]]
     for i, t in enumerate(use_text_units):
         print(t)
-        text_units_section_list.append([i, t["content"], t["file_path"], t["start"]["line"], t["end"]["line"]])
+        text_units_section_list.append(
+            [i, t["content"], t["file_path"], t["start"]["line"], t["end"]["line"]]
+        )
     text_units_context = list_of_list_to_csv(text_units_section_list)
     return f"""
 -----Entities-----
@@ -895,7 +897,9 @@ async def _build_global_query_context(
     text_units_section_list = [["id", "content", "file_path", "start_line", "end_line"]]
     for i, t in enumerate(use_text_units):
         print(t)
-        text_units_section_list.append([i, t["content"], t["file_path"], t["start"]["line"], t["end"]["line"]])
+        text_units_section_list.append(
+            [i, t["content"], t["file_path"], t["start"]["line"], t["end"]["line"]]
+        )
     text_units_context = list_of_list_to_csv(text_units_section_list)
 
     return f"""

--- a/tests/chunking/test_code_chunker.py
+++ b/tests/chunking/test_code_chunker.py
@@ -25,7 +25,7 @@ def function2():
         with open(file_path, "w") as f:
             f.write(test_code)
 
-        chunks = chunker.chunk_file(file_path)
+        chunks = chunker.chunk_file(file_path, test_code)
 
         assert len(chunks) == 1
         assert chunks[0]["content"] == test_code
@@ -88,7 +88,7 @@ def function2():
         with open(file_path, "w") as f:
             f.write(test_code)
 
-        chunks = chunker.chunk_file(file_path)
+        chunks = chunker.chunk_file(file_path, test_code)
         assert len(chunks) > 1
         assert all(
             chunk["token_count"] <= chunker.target_tokens + chunker.overlap_token_size

--- a/tests/chunking/test_language_support.py
+++ b/tests/chunking/test_language_support.py
@@ -259,7 +259,7 @@ end"""
             f.write(code)
 
         # Use chunk_file instead of chunk_code
-        chunks = chunker.chunk_file(file_path)
+        chunks = chunker.chunk_file(file_path, code)
 
         # Basic assertions
         assert len(chunks) > 0


### PR DESCRIPTION
This commit enhances the CodeChunker class to include start and end line information for each code chunk. It also updates the query context building functions to include this new information.

- Modify the `_chunking_by_token_size` method in `CodeChunker` to calculate start and end line numbers for each chunk
- Update the `CodeChunk` creation to include the new line information
- Modify `_build_local_query_context` and `_build_global_query_context` to include start and end line numbers in the text units context
- Update `chunk_file` method to require an additional parameter for file content
- Modify test files to align with the updated `chunk_file` method signature
- Implement various code style and linting improvements across multiple files
- Bump version to 1.0.8 in `lightrag/__init__.py`

Notes: The changes aim to provide more precise location information for code chunks, which can be useful for various operations and improved context in queries. This enhancement allows for better tracking and referencing of specific code sections within files.

User notes: add start end lines in context

Breaking changes: The `chunk_file` method in the `CodeChunker` class now requires an additional parameter for the file content. This change may break existing code that calls this method without providing the content parameter.

*Created with [Palmier](https://www.palmier.io)*