### PR TITLE
[refactor] Improve return types and error handling in _get_node_data …

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -783,11 +783,11 @@ async def _get_node_data(
     entities_vdb: BaseVectorStorage,
     text_chunks_db: BaseKVStorage[TextChunkSchema],
     query_param: QueryParam,
-):
+) -> tuple[str, str, str]:
     # get similar entities
     results = await entities_vdb.query(query, top_k=query_param.top_k)
     if not len(results):
-        return None
+        return "", "", ""
     # get entity information
     node_datas = await asyncio.gather(
         *[knowledge_graph_inst.get_node(r["entity_name"]) for r in results]
@@ -976,11 +976,11 @@ async def _get_edge_data(
     relationships_vdb: BaseVectorStorage,
     text_chunks_db: BaseKVStorage[TextChunkSchema],
     query_param: QueryParam,
-):
+) -> tuple[str, str, str]:
     results = await relationships_vdb.query(keywords, top_k=query_param.top_k)
 
     if not len(results):
-        return None
+        return "", "", ""
 
     edge_datas = await asyncio.gather(
         *[knowledge_graph_inst.get_edge(r["src_id"], r["tgt_id"]) for r in results]


### PR DESCRIPTION
### Description

This pull request refactors the `_get_node_data` and `_get_edge_data` functions in the `lightrag/operate.py` file to improve type safety and error handling. The changes include:

Update the return type annotations for _get_node_data and _get_edge_data functions to explicitly return a tuple of three strings. Modify the error handling to return empty strings instead of None when no results are found.

- Add return type annotation `-> tuple[str, str, str]` to both functions
- Replace `return None` with `return "", "", ""` in both functions

Notes: This change improves type safety and consistency in error handling, making the code more robust and easier to maintain. The explicit return type annotation helps with static type checking and code readability.

These modifications enhance code robustness, maintainability, and readability. The explicit return type annotations facilitate static type checking, while the consistent error handling improves the overall reliability of the code.

Key changes:

- In `_get_node_data`:
  - Added return type annotation: `-> tuple[str, str, str]`
  - Changed `return None` to `return "", "", ""`

- In `_get_edge_data`:
  - Added return type annotation: `-> tuple[str, str, str]`
  - Changed `return None` to `return "", "", ""`

These changes ensure that both functions always return a tuple of three strings, even in cases where no results are found, promoting consistency in the codebase.

### Changes that Break Backward Compatibility

The modifications to `_get_node_data` and `_get_edge_data` functions may potentially break backward compatibility for any code that relies on these functions returning `None` in case of no results. Now, they will always return a tuple of empty strings instead. Developers using these functions should update their code to handle the new return value appropriately.

### Documentation

N/A

*Created with [Palmier](https://www.palmier.io)*