### PR TITLE
Chunk query if exceed limit

### DIFF
--- a/lightrag/__init__.py
+++ b/lightrag/__init__.py
@@ -1,5 +1,5 @@
 from .lightrag import LightRAG as LightRAG, QueryParam as QueryParam
 
-__version__ = "1.0.11"
+__version__ = "1.0.12"
 __author__ = "Original: Zirui Guo, Modified: Harrison Tin"
 __url__ = "https://github.com/palmier-io/palmier-lightrag"

--- a/lightrag/kg/qdrant_impl.py
+++ b/lightrag/kg/qdrant_impl.py
@@ -48,7 +48,7 @@ class QdrantStorage(BaseVectorStorage):
 
         if not url or not api_key:
             raise ValueError("QDRANT_URL and QDRANT_API_KEY must be set")
-        
+
         self.repository = self.global_config.get("repository_name")
         self.repository_id = self.global_config.get("repository_id")
 
@@ -195,7 +195,11 @@ class QdrantStorage(BaseVectorStorage):
             )
 
             return [
-                {**hit.payload, "id": hit.payload["original_id"], "score": round(hit.score, 4)}
+                {
+                    **hit.payload,
+                    "id": hit.payload["original_id"],
+                    "score": round(hit.score, 4),
+                }
                 for hit in results
             ]
         except Exception as e:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -544,6 +544,8 @@ async def kg_query(
     global_config: dict,
     hashing_kv: BaseKVStorage = None,
 ) -> str:
+    if query.strip() == "":
+        return PROMPTS["fail_response"]
     # Handle cache
     use_model_func = global_config["llm_model_func"]
     args_hash = compute_args_hash(query_param.mode, query)
@@ -570,14 +572,27 @@ async def kg_query(
         return PROMPTS["fail_response"]
 
     # Get relevant summaries
-    summaries = await summaries_vdb.query(query, top_k=query_param.top_k)
+    query_chunks = chunking_by_token_size(
+        query,
+        overlap_token_size=global_config["chunk_overlap_token_size"],
+        max_token_size=global_config["chunk_token_size"],
+        tiktoken_model=global_config["tiktoken_model_name"],
+    )
+    summaries = await asyncio.gather(*[summaries_vdb.query(chunk["content"], top_k=query_param.top_k) for chunk in query_chunks])
+    summaries = [item for sublist in summaries for item in sublist]
     summary_context = [["id", "level", "file_path", "score", "content"]]
+    seen_file_paths = set()
+    
     for i, s in enumerate(summaries):
+        file_path = s["file_path"]
+        if file_path in seen_file_paths:
+            continue
+        seen_file_paths.add(file_path)
         summary_context.append(
             [
                 i,
                 s["type"],
-                s["file_path"],
+                file_path,
                 s["score"],
                 s["content"],
             ]

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -578,11 +578,16 @@ async def kg_query(
         max_token_size=global_config["chunk_token_size"],
         tiktoken_model=global_config["tiktoken_model_name"],
     )
-    summaries = await asyncio.gather(*[summaries_vdb.query(chunk["content"], top_k=query_param.top_k) for chunk in query_chunks])
+    summaries = await asyncio.gather(
+        *[
+            summaries_vdb.query(chunk["content"], top_k=query_param.top_k)
+            for chunk in query_chunks
+        ]
+    )
     summaries = [item for sublist in summaries for item in sublist]
     summary_context = [["id", "level", "file_path", "score", "content"]]
     seen_file_paths = set()
-    
+
     for i, s in enumerate(summaries):
         file_path = s["file_path"]
         if file_path in seen_file_paths:
@@ -662,7 +667,9 @@ async def kg_query(
         return PROMPTS["fail_response"]
     sys_prompt_temp = PROMPTS["rag_response"]
     sys_prompt = sys_prompt_temp.format(
-        context_data=context, response_type=query_param.response_type, repository_name=global_config.get("repository_name")
+        context_data=context,
+        response_type=query_param.response_type,
+        repository_name=global_config.get("repository_name"),
     )
     if query_param.only_need_prompt:
         return sys_prompt

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -575,7 +575,7 @@ async def kg_query(
     query_chunks = chunking_by_token_size(
         query,
         overlap_token_size=global_config["chunk_overlap_token_size"],
-        max_token_size=global_config["chunk_token_size"],
+        max_token_size=8192, # limit for text-embedding-3-small
         tiktoken_model=global_config["tiktoken_model_name"],
     )
     summaries = await asyncio.gather(

--- a/lightrag/storage.py
+++ b/lightrag/storage.py
@@ -171,7 +171,13 @@ class NanoVectorDBStorage(BaseVectorStorage):
             better_than_threshold=self.cosine_better_than_threshold,
         )
         results = [
-            {**dp, "id": dp["__id__"], "distance": dp["__metrics__"], "score": dp["__metrics__"]} for dp in results
+            {
+                **dp,
+                "id": dp["__id__"],
+                "distance": dp["__metrics__"],
+                "score": dp["__metrics__"],
+            }
+            for dp in results
         ]
         return results
 


### PR DESCRIPTION
### Description

This pull request enhances the `kg_query` function in the LightRAG library to handle large queries more effectively. The main changes include:

1. Implementing query chunking to process long queries in smaller parts, addressing the summary limit token issue.
2. Adding deduplication of summaries based on file paths to reduce redundancy in results.
3. Handling empty queries by returning a fail response.
4. Updating the max token size for text embedding to 8192, which is the limit for the text-embedding-3-small model.

The changes are implemented across multiple files, including `lightrag/operate.py`, `lightrag/kg/qdrant_impl.py`, and `lightrag/storage.py`. The version number in `lightrag/__init__.py` is updated to `1.0.12`.

Key modifications in the `kg_query` function include:

- Chunking the query using `chunking_by_token_size` function.
- Using `asyncio.gather` to process query chunks concurrently.
- Implementing deduplication logic for summaries based on file paths.
- Setting a hardcoded max token size of 8192 for text embedding.

These changes aim to improve the handling of large queries, enhance result quality, and optimize performance when dealing with extensive input.

### Changes that Break Backward Compatibility

N/A

### Documentation

N/A

*Created with [Palmier](https://www.palmier.io)*